### PR TITLE
CASMTRIAGE-7663: Add python3-typing_extensions dependency

### DIFF
--- a/python-bos-reporter.spec
+++ b/python-bos-reporter.spec
@@ -49,6 +49,7 @@ BuildRequires: python-rpm-generators
 BuildRequires: python-rpm-macros
 BuildRequires: systemd-rpm-macros
 Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
+Requires: python3-typing_extensions
 Requires: systemd
 Requires: cray-auth-utils
 Requires: spire-agent


### PR DESCRIPTION
## Summary and Scope

After some refactoring, the bos-reporter needs Python's typing_extensions module installed.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

I'll test it once it's built.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

