### PR TITLE
CASMCMS-9337: Resume building RPMs for Python 3.6 and 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Resume building RPMs for Python 3.6 and 3.9
+
+### Changed
+
+- Updated `pyproject.toml` to explicitly list Python 3.13 support
+- Refactored Jenkinsfile to reduce size of main pipeline, to work around Jenkins limitation on its total size
+
 ### Dependencies
+
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#2](https://github.com/Cray-HPE/bos-reporter/pull/2))
 - Bump `tj-actions/changed-files` from 45 to 46 ([#8](https://github.com/Cray-HPE/bos-reporter/pull/8))
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#2](https://github.com/Cray-HPE/bos-reporter/pull/2))
 
 ## [3.3.2] - 2025/03/06
 
-### Changed
+### Added
 
 - Build RPMs for SLES SP7
 - Build RPMs for python 3.13
+
+### Removed
+
+- No longer build RPMs for Python 3.6 and 3.9
 
 ## [3.3.1] - 2025/02/07
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -28,6 +28,7 @@
 
 def pyImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
+def pyModBuildPyVersion = '3.13'
 
 def buildRootReldir() {
     return "dist/rpmbuild"
@@ -75,6 +76,59 @@ def publishRpms(rpmName, rpmOs, rpmArch, buildReldir) {
     )
 }
 
+def initPrep() {
+    // This function is defined in cms-meta-tools:vars/cloneCMSMetaTools.groovy
+    cloneCMSMetaTools()
+
+    // This function is defined in cms-meta-tools:vars/setVersionFiles.groovy
+    setVersionFiles()
+
+    withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+        sh "make runbuildprep"
+    }
+
+    sh "make lint"
+
+    runLibraryScript("addRpmMetaData.sh", "${env.WORKSPACE}/${env.META_RPM_SPEC_FILE}")
+    runLibraryScript("addRpmMetaData.sh", "${env.WORKSPACE}/${env.SPEC_FILE}")
+
+    // This generates the netrc file that we need
+    getDockerBuildArgs()
+}
+
+def dockerPullAndTag(dockerArch, sourceDockerImage, dockerBuildImage) {
+    lock('docker-image-pull') {
+        sh "docker pull --platform linux/${dockerArch} ${sourceDockerImage}"
+        sh "docker tag ${sourceDockerImage} ${dockerBuildImage}"
+    }
+}
+
+def buildAndPublishPythonRpms() {
+    def rpmVersion = sh(script: "head -1 .version", returnStdout: true).trim()
+    def rpmRelease = sh(script: "head -1 .rpm_release", returnStdout: true).trim()
+    def rpmName = getRpmName(env.NAME, env.PY_VERSION)
+    def sleVersion = getSleVersion()
+    def rpmOs = getSleRpmOs(sleVersion)
+    def buildRelDir = buildRelDir(env.RPM_NAME, rpmOs, env.RPM_ARCH)
+
+    withEnv(["RPM_VERSION=${rpmVersion}",
+             "RPM_RELEASE=${rpmRelease}",
+             "SLE_VERSION=${sleVersion}",
+             "RPM_OS=${rpmOs}",
+             "RPM_NAME=${rpmName}",
+             "BUILD_RELDIR=${buildRelDir}"]) {
+        buildCsmRpms(
+            name: rpmName,
+            version: rpmVersion,
+            sourceTarPath: env.GENERIC_PY_RPM_SOURCE_TAR,
+            specFileBasename: env.SPEC_FILE,
+            buildReldir: buildRelDir,
+            arch: env.RPM_ARCH,
+        )
+    }
+    publishRpms(rpmName, rpmOs, env.RPM_ARCH, buildRelDir)
+}
+
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -91,7 +145,6 @@ pipeline {
         NAME = "bos-reporter"
         DESCRIPTION = "Configuration Framework Service Trust Environment"
         IS_STABLE = getBuildIsStable()
-        PYMOD_BUILD_PY_VERSION = "3.12"
         BUILD_ROOT_RELDIR = buildRootReldir()
         META_RPM_OS = "noos"
         META_RPM_NAME = "${env.NAME}"
@@ -104,33 +157,9 @@ pipeline {
     }
 
     stages {
-        stage("Init") {
+        stage("Init & Prep") {
             steps {
-                // This function is defined in cms-meta-tools:vars/cloneCMSMetaTools.groovy
-                cloneCMSMetaTools()
-
-                // This function is defined in cms-meta-tools:vars/setVersionFiles.groovy
-                setVersionFiles()
-
-                withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
-                    sh "make runbuildprep"
-                }
-            }
-        }
-
-        stage ("Prep") {
-            steps {
-                sh "make lint"
-
-                // The RPM build metadata can be added outside of the matrix, because it is just based on the
-                // Git commit being built
-                runLibraryScript("addRpmMetaData.sh", "${env.WORKSPACE}/${env.META_RPM_SPEC_FILE}")
-                runLibraryScript("addRpmMetaData.sh", "${env.WORKSPACE}/${env.SPEC_FILE}")
-
-                // Just using this as a means to generate the netrc file that we need
-                getDockerBuildArgs()
-
-                sh "make pre_clean"
+                initPrep()
             }
         }
 
@@ -139,12 +168,12 @@ pipeline {
                 docker {
                     args '-v /home/jenkins/.ssh:/home/jenkins/.ssh -v /home/jenkins/.netrc:/home/jenkins/.netrc'
                     reuseNode true
-                    image "${pyImage}:${PYMOD_BUILD_PY_VERSION}"
+                    image "${pyImage}:${pyModBuildPyVersion}"
                 }
             }
             environment {
-                PY_VERSION = "${PYMOD_BUILD_PY_VERSION}"
-                PY_PATH = getPythonBinaryPath(env.PYMOD_BUILD_PY_VERSION)
+                PY_VERSION = "${pyModBuildPyVersion}"
+                PY_PATH = getPythonBinaryPath(pyModBuildPyVersion)
             }
             steps {
                 sh "make pymod_build"
@@ -171,9 +200,7 @@ pipeline {
                 stages {
                     stage("Pylint") {
                         steps {
-                            sh "make pymod_pylint_setup"
-                            sh "make pymod_pylint_errors"
-                            sh "make pymod_pylint_full"
+                            sh "make pymod_pylint"
                         }
                     }
                 }
@@ -193,7 +220,7 @@ pipeline {
                         name 'DOCKER_TAG'
                         // $pyImage:$PY_VERSION implies the SLES version used for the build
                         // $pyImage:$PY_VERSION-SLES15.5 dictates the python version and SLES version
-                        values '3.10', '3.11-SLES15.5', '3.11-SLES15.6','3.11-SLES15.7', '3.12', '3.13'
+                        values '3.6', '3.9', '3.10', '3.11-SLES15.5', '3.11-SLES15.6','3.11-SLES15.7', '3.12', '3.13'
                     }
                     axis {
                         name 'RPM_ARCH'
@@ -203,22 +230,15 @@ pipeline {
                 environment {
                     DOCKER_ARCH = sh(returnStdout: true, script: "[ ${RPM_ARCH} == 'x86_64' ] && echo -n 'amd64' || echo -n 'arm64'")
                     PY_VERSION = sh(script: "echo \${DOCKER_TAG%%-*}", returnStdout: true).trim()
-                    SOURCE_DOCKER_IMAGE = "${pyImage}:${DOCKER_TAG}"
-                    DOCKER_BUILD_IMAGE = "${SOURCE_DOCKER_IMAGE}-${DOCKER_ARCH}"
-                    RPM_NAME = getRpmName(env.NAME, env.PY_VERSION)
-                    RPM_VERSION = sh(script: "head -1 .version", returnStdout: true).trim()
-                    RPM_RELEASE = sh(script: "head -1 .rpm_release", returnStdout: true).trim()
+                    DOCKER_BUILD_IMAGE = "${pyImage}:${DOCKER_TAG}-${DOCKER_ARCH}"
                 }
                 stages {
                     stage('Pull & tag') {
                         steps {
-                            lock('docker-image-pull') {
-                                sh "docker pull --platform linux/${DOCKER_ARCH} ${SOURCE_DOCKER_IMAGE}"
-                                sh "docker tag ${SOURCE_DOCKER_IMAGE} ${DOCKER_BUILD_IMAGE}"
-                            }
+                            dockerPullAndTag(env.DOCKER_ARCH, "${pyImage}:${DOCKER_TAG}", env.DOCKER_BUILD_IMAGE)
                         }
                     }
-                    stage("Build") {
+                    stage("Build & Publish") {
                         agent {
                             docker {
                                 reuseNode true
@@ -226,39 +246,8 @@ pipeline {
                                 image "${DOCKER_BUILD_IMAGE}"
                             }
                         }
-                        environment {
-                            SLE_VERSION = getSleVersion()
-                            RPM_OS = getSleRpmOs(env.SLE_VERSION)
-                            BUILD_RELDIR = buildRelDir(env.RPM_NAME, env.RPM_OS, env.RPM_ARCH)
-                        }
                         steps {
-                            script {
-                                buildCsmRpms(
-                                    name: env.RPM_NAME,
-                                    version: RPM_VERSION,
-                                    sourceTarPath: env.GENERIC_PY_RPM_SOURCE_TAR,
-                                    specFileBasename: env.SPEC_FILE,
-                                    buildReldir: env.BUILD_RELDIR,
-                                    arch: env.RPM_ARCH,
-                                )
-                            }
-                        }
-                    }
-                    stage ("Publish") {
-                        agent {
-                            docker {
-                                reuseNode true
-                                args "-v /home/jenkins/.ssh:/home/jenkins/.ssh -v /home/jenkins/.netrc:/home/jenkins/.netrc --platform linux/${DOCKER_ARCH}"
-                                image "${DOCKER_BUILD_IMAGE}"
-                            }
-                        }
-                        environment {
-                            SLE_VERSION = getSleVersion()
-                            RPM_OS = getSleRpmOs(env.SLE_VERSION)
-                            BUILD_RELDIR = buildRelDir(env.RPM_NAME, env.RPM_OS, env.RPM_ARCH)
-                        }
-                        steps {
-                            publishRpms(env.RPM_NAME, env.RPM_OS, env.RPM_ARCH, env.BUILD_RELDIR)
+                            buildAndPublishPythonRpms()
                         }
                     }
                 }

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ RPM_VERSION ?= $(shell head -1 .version)
 RPM_RELEASE ?= $(shell head -1 .rpm_release)
 
 PIP_INSTALL_ARGS ?= --trusted-host arti.hpc.amslabs.hpecorp.net --trusted-host artifactory.algol60.net --index-url https://arti.hpc.amslabs.hpecorp.net:443/artifactory/api/pypi/pypi-remote/simple --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple -c constraints.txt --no-cache
-PY_VERSION ?= 3.12
+PY_VERSION ?= 3.13
 RPM_ARCH ?= x86_64
 RPM_OS ?= sle15-sp6
 SLE_VERSION ?= 15.6
@@ -55,7 +55,8 @@ TMPDIR := $(shell mktemp -d $(PWD)/.tmp.$(RPM_ARCH).$(PY_VERSION).$(SLE_VERSION)
 META_BUILD_DIR ?= $(TMPDIR)/$(META_BUILD_RELDIR)
 
 meta_rpm: meta_rpm_prepare meta_rpm_build_source meta_rpm_build meta_rpm_post_clean
-pymod: pymod_build pymod_pylint_setup pymod_pylint_errors pymod_pylint_full
+pymod_pylint: pymod_pylint_setup pymod_pylint_errors pymod_pylint_full
+pymod: pymod_build pymod_pylint
 
 runbuildprep:
 		./cms_meta_tools/scripts/runBuildPrep.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 description = 'BOS state reporter.'
 dependencies = [ 'requests', 'requests-retry-session', 'urllib3' ]


### PR DESCRIPTION
[The PR for MTL-2542](https://github.com/Cray-HPE/bos-reporter/pull/3) added some additional versions of Python RPMs being built. However, due to a [Java/Jenkins limitation](https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/troubleshooting-guides/method-code-too-large-error), he had to removed the builds for Python 3.6 and 3.9 in order for the Jenkins build to succeed.

Unfortunately, this caused image customization failures for some images. This PR restores the removed versions. In order to do this, the Jenkinsfile had to be refactored somewhat to reduce the size of the main `pipeline` code, combining some things and moving some other things into separate methods defined at the top of the Jenkinsfile. This did not change the overall build logic.

I also updated a couple of places to indicate the Python 3.13 support, and updated the CHANGELOG to make clear when the 3.6/3.9 RPMs were removed from the builds, and then added back.

No backports are needed for this -- this is a problem only in the latest versions of `bos-reporter`.